### PR TITLE
fix: sidenav z-index > navbar z-index

### DIFF
--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -154,7 +154,7 @@
 
   .sidebar.scrolling {
     top: 0;
-    z-index: 100;
+    z-index: 1031;
   }
 
   .shade.shown {


### PR DESCRIPTION
I change the z-index of sidenav to be greater than navbar z-index

Issue: Navbar overlaying sidebar on small devices #584
