### PR TITLE
Fix fill-animation on rounded buttons

### DIFF
--- a/dist/sbuttons.css
+++ b/dist/sbuttons.css
@@ -412,7 +412,7 @@ a.yellow-btn:active:not(.fill-color-btn) {
   border-radius: 25px;
 }
 .aurapulse-btn:hover:before {
-  animation: aurapulse 0.4s infinite;
+  animation: aurapulse 0.5s infinite;
 }
 @keyframes aurapulse {
   0% {
@@ -505,11 +505,20 @@ a.yellow-btn:active:not(.fill-color-btn) {
 .fill-color-btn:hover {
   color: #fff !important;
 }
+.fill-color-btn.rounded-btn {
+  transition: background 0s cubic-bezier(0.39, 0.58, 0.57, 1) 0s;
+}
+.fill-color-btn.rounded-btn:hover {
+  transition: background 0.03s cubic-bezier(0.39, 0.58, 0.57, 1) 0.15s;
+}
 .fill-color-btn.blue-btn {
   border-color: #50bfe6 !important;
   color: #50bfe6;
 }
 .fill-color-btn.blue-btn:before {
+  background-color: #50bfe6;
+}
+.fill-color-btn.blue-btn.rounded-btn:hover {
   background-color: #50bfe6;
 }
 .fill-color-btn.pink-btn {
@@ -519,6 +528,9 @@ a.yellow-btn:active:not(.fill-color-btn) {
 .fill-color-btn.pink-btn:before {
   background-color: #d53caf;
 }
+.fill-color-btn.pink-btn.rounded-btn:hover {
+  background-color: #d53caf;
+}
 .fill-color-btn.green-btn {
   border-color: #3aa655 !important;
   color: #3aa655;
@@ -526,11 +538,17 @@ a.yellow-btn:active:not(.fill-color-btn) {
 .fill-color-btn.green-btn:before {
   background-color: #3aa655;
 }
+.fill-color-btn.green-btn.rounded-btn:hover {
+  background-color: #3aa655;
+}
 .fill-color-btn.yellow-btn {
   border-color: #fbe870 !important;
   color: #fbe870;
 }
 .fill-color-btn.yellow-btn:before {
+  background-color: #fbe870;
+}
+.fill-color-btn.yellow-btn.rounded-btn:hover {
   background-color: #fbe870;
 }
 .fill-color-btn.yellow-btn:hover {
@@ -543,11 +561,17 @@ a.yellow-btn:active:not(.fill-color-btn) {
 .fill-color-btn.orange-btn:before {
   background-color: #ff8833;
 }
+.fill-color-btn.orange-btn.rounded-btn:hover {
+  background-color: #ff8833;
+}
 .fill-color-btn.red-btn {
   border-color: #ed0a3f !important;
   color: #ed0a3f;
 }
 .fill-color-btn.red-btn:before {
+  background-color: #ed0a3f;
+}
+.fill-color-btn.red-btn.rounded-btn:hover {
   background-color: #ed0a3f;
 }
 .fill-color-btn.purple-btn {
@@ -557,11 +581,17 @@ a.yellow-btn:active:not(.fill-color-btn) {
 .fill-color-btn.purple-btn:before {
   background-color: #652dc1;
 }
+.fill-color-btn.purple-btn.rounded-btn:hover {
+  background-color: #652dc1;
+}
 .fill-color-btn.black-btn {
   border-color: #000 !important;
   color: #000;
 }
 .fill-color-btn.black-btn:before {
+  background-color: #000;
+}
+.fill-color-btn.black-btn.rounded-btn:hover {
   background-color: #000;
 }
 .fill-color-btn.white-btn {
@@ -571,6 +601,9 @@ a.yellow-btn:active:not(.fill-color-btn) {
   color: #333;
 }
 .fill-color-btn.white-btn:before {
+  background-color: #fff;
+}
+.fill-color-btn.white-btn.rounded-btn:hover {
   background-color: #fff;
 }
 .fill-color-btn.white-btn:hover {

--- a/src/components/animated/_fill.less
+++ b/src/components/animated/_fill.less
@@ -67,6 +67,20 @@
     &:before {
       .bc(@color);
     }
+
+    &.rounded-btn {
+      &:hover {
+        .bc(@color);
+      }
+    }
+  }
+
+  &.rounded-btn {
+    transition: background 0s cubic-bezier(0.39, 0.58, 0.57, 1) 0s;
+
+    &:hover {
+      transition: background 0.03s cubic-bezier(0.39, 0.58, 0.57, 1) 0.15s;
+    }
   }
 
   &.blue-btn {


### PR DESCRIPTION
Fix the white/transparent line on the right of the button for buttons with a fill animation and rounded corners (.fill-color-btn .rounded-btn) on Safari (webkit) on iOs and macOs.

Issue: #54 
