### PR TITLE
Changed glossy button border

### DIFF
--- a/dist/sbuttons.css
+++ b/dist/sbuttons.css
@@ -261,6 +261,7 @@ a.yellow-btn:active:not(.fill-color-btn) {
   user-select: none;
 }
 .glossy-btn {
+  border: none;
   border-radius: 50px;
   padding: 5px 20px;
   position: relative;

--- a/src/components/styles/_glossy-btn.less
+++ b/src/components/styles/_glossy-btn.less
@@ -1,4 +1,5 @@
 .glossy-btn {
+  border: none;
   border-radius: 50px;
   padding: 5px 20px;
   position: relative;


### PR DESCRIPTION
I added a "border: none" to the glossy-btn class because I noticed the glossy buttons had a border that cut off the glossy white part of the button. When I saw them for the first time that part kind of threw me off so that's why I changed it to this. 
