### PR TITLE
Removed the double outline button in side nav bar

### DIFF
--- a/assets/js/buttons-examples.js
+++ b/assets/js/buttons-examples.js
@@ -101,11 +101,7 @@ $(document).ready(function () {
           label: "Key",
           classes: "key-btn",
         },
-        {
-          type: "outline",
-          label: "Outline",
-          classes: "outline-btn",
-        },
+        
         {
           type: "rounded-bottom",
           label: "Rounded Bottom",


### PR DESCRIPTION

<!-- Please describe what changes or additions this pull request pertain to -->
Removed the repeated outline button from **Button Styles** section in **side navbar**.
<!-- Specify the issue it relates to, if any --->
**Issue #824** : There are **2 outline button** section in the website . They both are **same** .
