### PR TITLE
Removed two outline buttons

### DIFF
--- a/assets/js/buttons-examples.js
+++ b/assets/js/buttons-examples.js
@@ -59,19 +59,7 @@ $(document).ready(function () {
           label: "Gradient",
           classes: "gradient-btn",
         },
-        {
-          type: "outline",
-          label: "Outline",
-          classes: "outline-btn",
-
-          type: "outline",
-          label: "Outline",
-          classes: "outline-btn",
-
-          type: "outline",
-          label: "Outline",
-          classes: "outline-btn",
-        },
+       
         {
           type: "xsmall",
           label: "Extra-small",


### PR DESCRIPTION
**Removed the repeated outline button** from Button Styles section from side navbar and updated according to **alphabetical order.**

**Issue #824 :** There are 2 outline button section in the website . They both are same .
