### PR TITLE
Do not launch the button examples script on the "Get Started" page

### DIFF
--- a/assets/js/buttons-examples.js
+++ b/assets/js/buttons-examples.js
@@ -59,7 +59,7 @@ $(document).ready(function () {
           label: "Gradient",
           classes: "gradient-btn",
         },
-       
+
         {
           type: "xsmall",
           label: "Extra-small",

--- a/assets/js/buttons-examples.js
+++ b/assets/js/buttons-examples.js
@@ -1,4 +1,10 @@
 $(document).ready(function () {
+  var sidebar = $(".sidebar-list");
+  var content = $("#content");
+  if (!sidebar.length || !content.length) {
+    return;
+  }
+
   //default button class
   var defaultClass = "sbtn";
   //button color variations
@@ -636,9 +642,6 @@ $(document).ready(function () {
       ],
     },
   ];
-
-  var sidebar = $(".sidebar-list"),
-    content = $("#content");
 
   /**
    * getButttonHtml generates the required html for each button to be rendered

--- a/getStarted.html
+++ b/getStarted.html
@@ -90,7 +90,7 @@
                         <a href="#cdn" class="submenu-link">Install with CDN</a>
                         <a href="#npm" class="submenu-link">Install with NPM</a>
                     </div>
-                    
+
                     <a href="#usage" class="usage has-children-links">Usage</a>
                     <div class="submenu-links">
                         <a href="#modify" class="submenu-link">Modify Button Colors</a>
@@ -119,7 +119,7 @@
                         <a href="#right-icon-rounded" class="submenu-link">Rounded button right</a>
                       </div>
                       <!-- rounded button submenu links go here -->
-                      
+
                       <!-- block button submenu links go here -->
                       <a href="#block" class="block has-children-links">Block buttons</a>
                       <div class="submenu-links">
@@ -161,10 +161,10 @@
                     <div class="text">
                       Make sure to replace
                       <span class="code-text">"/path/to/sbuttons.min.css"</span> with the path you stored it in.
-                    </div> 
+                    </div>
                     <br>
                 </section>
-                
+
                 <section class="instruction-block" id="cdn">
                     <h2>CDN</h2>
                     <hr class="secondary-hr"  />
@@ -191,7 +191,7 @@
                     </div>
                     <br>
                 </section>
-                
+
                 <section class="instruction-block" id="npm">
                     <h2>NPM</h2>
                     <hr class="secondary-hr" />
@@ -209,7 +209,7 @@
                     </div>
                     <br />
                 </section>
-                
+
                 <h2 id="usage">Usage</h2>
 
                 <section class="instruction-block" id="modify">
@@ -252,7 +252,7 @@
                     </div>
                     <br>
                 </section>
-                
+
                 <section class="instruction-block" id="block">
                     <h2>Block Buttons</h2>
                     <button class="sbtn basic-btn blue-btn block-btn">Button</button>
@@ -268,7 +268,7 @@
                     </div>
                     <br />
                 </section>
-                
+
                 <section class="instruction-block" id="disabled">
                     <h2 class="display-inlineBlock">Disabled Buttons</h2>
                     <button class="sbtn basic-btn blue-btn disabled-btn display-inlineBlock margin-left--half">Button</button>
@@ -305,14 +305,14 @@
                   The <code>base-icon-btn</code> class enables you to have a normal, customizable button. Using it, you decide to add any fontawesome icon in it. You can choose to either place it on the left or right side of the button with the available classes which you will see below.
                   For the icon to be positioned well in the button, you should place the button text after the fontawesome icon if you want the icon to be on the left side of the button and vice versa for the right icon too.
                 </div>
-                <br />   
+                <br />
                 <!-- base button class without any icon starts here -->
                 <section class="instruction-block" id="base">
                     <div class="text">
                       <h2 class="display-inlineBlock">Base button</h2>
                       <button class="sbtn base-icon-btn">
                         <i class="fas fa-book"></i>
-                      </button>  
+                      </button>
                       <div class="text">
                         The <code>base-icon-btn</code> class, gives you a default button with no background color and a border. You can choose to style it by adding, some of the other available classes, like <code>btn-orange</code> to change the background color, and <code>icon-right</code> to position the icon in the button. You can make use of it, by copying the snippet below.
                       </div>
@@ -323,8 +323,8 @@
                         <pre><code class="language-markup">&lt;button class="sbtn base-icon-btn"&gt;base icon button&lt;/button&gt;</code></pre>
                         <div class="div-copy"><button class="clipboard"></button></div>
                       </div>
-                    </div> 
-                </section>            
+                    </div>
+                </section>
                 <!-- base button class ends here -->
                 <br />
                 <!-- left base icon button class starts here -->
@@ -333,8 +333,8 @@
                     <h2 class="display-inlineBlock">Left icon button</h2>
                     <button class="sbtn base-icon-btn left-icon orange-btn">
                       <i class="fab fa-github"></i>
-                      left icon 
-                    </button>  
+                      left icon
+                    </button>
                     <br />
                     <div class="text">
                       Adding the <code>left-icon</code> and <code>orange-btn</code> class gives you a button with an orange background and an icon that is on the left.
@@ -347,7 +347,7 @@
                       <div class="div-copy"><button class="clipboard"></button></div>
                     </div>
                   </div>
-                </section>                  
+                </section>
                 <!-- left base icon button class ends here -->
                 <br />
                 <!-- base icon center starts here -->
@@ -378,7 +378,7 @@
                   <div class="text">
                     <h2 class="display-inlineBlock">Right icon button</h2>
                     <button class="sbtn base-icon-btn icon-right orange-btn">
-                      right icon 
+                      right icon
                       <i class="fab fa-github"></i>
                     </button>
                     <br />
@@ -394,7 +394,7 @@
                         <div class="div-copy"><button class="clipboard"></button></div>
                       </div>
                   </div>
-                </section>    
+                </section>
                 <!-- right icon base class ends here -->
                 <br />
                 <!-- rounded icon buttons start here -->
@@ -404,8 +404,8 @@
                     <h2 class="display-inlineBlock">Left icon rounded button</h2>
                     <button class="sbtn base-icon-btn left-icon purple-btn rounded-btn">
                       <i class="fab fa-github"></i>
-                      right icon rounded 
-                    </button>  
+                      right icon rounded
+                    </button>
                     <br />
                     <div class="text">
                       Adding the <code>left-icon</code>, <code>rounded-btn</code> and <code>purple-btn</code> class gives you a button with a purple background and an icon that is on the left.
@@ -417,8 +417,8 @@
                       <pre><code class="language-markup">&lt;button class="sbtn base-icon-btn icon-left purple-btn rounded-btn"&gt;&lt;i class="fab fa-github"&gt;&lt;/i&gt;left icon&lt;/button&gt;</code></pre>
                       <div class="div-copy"><button class="clipboard"></button></div>
                     </div>
-                  </div>               
-                </section>       
+                  </div>
+                </section>
                 <!-- rounded left icon class ends here -->
                 <br />
                 <!-- rounded button center starts here -->
@@ -441,7 +441,7 @@
                         <div class="div-copy"><button class="clipboard"></button></div>
                       </div>
                   </div>
-                </section>    
+                </section>
                 <!-- rounded button center ends here -->
                 <br />
                 <!-- rounded button right icon class starts here -->
@@ -449,7 +449,7 @@
                   <div class="text">
                     <h2 class="display-inlineBlock">Right icon rounded button</h2>
                     <button class="sbtn base-icon-btn icon-right rounded-btn purple-btn">
-                      right icon rounded 
+                      right icon rounded
                       <i class="fab fa-github"></i>
                     </button>
                     <br />
@@ -482,7 +482,7 @@
                     <button class="sbtn base-icon-btn left-icon green-btn block-btn">
                       <i class="fab fa-github"></i>
                       left icon block
-                    </button>  
+                    </button>
                     <br />
                     <div class="text">
                       Adding the <code>left-icon</code>, <code>block-btn</code> and <code>green-btn</code> class gives you a button with a green background and an icon that is on the left.
@@ -495,7 +495,7 @@
                       <div class="div-copy"><button class="clipboard"></button></div>
                     </div>
                   </div>
-                </section>                      
+                </section>
                 <!-- block button left icon class ends here -->
                 <br />
                 <!-- block button center starts here -->
@@ -526,7 +526,7 @@
                   <div class="text">
                     <h2 class="display-inlineBlock">Right icon block button</h2>
                     <button class="sbtn base-icon-btn icon-right block-btn green-btn">
-                      right icon block 
+                      right icon block
                       <i class="fab fa-github"></i>
                     </button>
                     <br />
@@ -543,7 +543,7 @@
                       </div>
                   </div>
                 </section>
-                <!--block button right ends here-->    
+                <!--block button right ends here-->
               <!-- block  buttons end here-->
             </section>
           </div>
@@ -564,7 +564,7 @@
         <div style="padding:20px 0 0 0; font-size: 13px;">Logo made by <a href="https://www.github.com/icoderharshit"
           title="Harshit Sharma">Harshit Sharma</a> </div>
   </footer>
-  
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.21.0/components/prism-core.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.21.0/plugins/autoloader/prism-autoloader.min.js"></script>
   <script src="https://code.jquery.com/jquery-3.5.1.min.js"

--- a/getStarted.html
+++ b/getStarted.html
@@ -571,7 +571,7 @@
     integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
-  <script src="assets/js/buttons-examples.js"></script>
+  <!-- <script src="assets/js/buttons-examples.js"></script> -->
   <script src="assets/js/index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
I noticed that `button-examples.js` is also called for `getStarted.html`. This script makes up the sample buttons for the home page, and as far as I'm concerned, it's not needed on the "[Getting Started](https://sbuttons.github.io/sbuttons/getStarted.html)" page.

At the same time a simple measurement shows that the script runs for about 500 ms for each page load:
```js
$(document).ready(function () {
    start = Date.now();
    // original code is here
    console.log( 'Unclaimed work lasted', Date.now() - start, 'ms' );
});
```
Due to this I've made two changes:

1. Commented out the call to the script. Now it is obvious that the script is not involved in this file.
2. Transfered to the beginning of the script the initialization of the pointers to the sidebar and to the block of the buttons. If one of them was not on the page, then I interrupt the script. The script will now stop even if it is run by mistake.

After disabling the script, the chrome developer tools show quite a significant improvement in page load performance.

![block-unused-scriot-perfomance](https://user-images.githubusercontent.com/3881568/96925349-4e952c80-14b4-11eb-868d-2cd22daf666f.png)

On the main page, the script works the same as before.