### PR TITLE
Better Neumorphic Buttons in Darkmode

### DIFF
--- a/dist/sbuttons.css
+++ b/dist/sbuttons.css
@@ -3863,6 +3863,16 @@ a.yellow-btn:active:not(.fill-color-btn) {
   box-shadow: inset -4px -4px 8px rgba(255, 255, 255, 0.1),
     inset 4px 4px 8px rgba(0, 0, 0, 0.1);
 }
+[data-theme="dark"] .neu-btn {
+  box-shadow: -4px -4px 8px rgba(255, 255, 255, 0.01),
+    4px 4px 8px rgba(0, 0, 0, 0.2);
+}
+[data-theme="dark"] .neu-btn:hover,
+[data-theme="dark"] .neu-btn:active,
+[data-theme="dark"] .neu-btn:focus {
+  box-shadow: inset -4px -4px 8px rgba(255, 255, 255, 0.01),
+    inset 4px 4px 8px rgba(0, 0, 0, 0.2);
+}
 @font-face {
   font-family: "Source Code Pro";
   font-style: normal;

--- a/src/components/special/_neumorphic.less
+++ b/src/components/special/_neumorphic.less
@@ -66,3 +66,14 @@
       inset 4px 4px 8px rgba(0, 0, 0, 0.1);
   }
 }
+[data-theme="dark"] .neu-btn {
+  box-shadow: -4px -4px 8px rgba(255, 255, 255, 0.01),
+    4px 4px 8px rgba(0, 0, 0, 0.2);
+
+  &:hover,
+  &:active,
+  &:focus {
+    box-shadow: inset -4px -4px 8px rgba(255, 255, 255, 0.01),
+      inset 4px 4px 8px rgba(0, 0, 0, 0.2);
+  }
+}


### PR DESCRIPTION
Made the neumorphic button shadows darker and highlights dimmer when the data-theme is set to dark.
Fixes: #902 

**Before -**
![opera_2020-10-23_06-17-02](https://user-images.githubusercontent.com/52884391/97046050-b14afe80-156e-11eb-8a08-7f24aeb32a56.png)

**After -**
![opera_2020-10-23_06-16-36](https://user-images.githubusercontent.com/52884391/97046081-c1fb7480-156e-11eb-9ebd-70e06c1b3ee3.png)


