### PR TITLE
Fix #862. Show all levels in the sidebar menu

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -46,7 +46,6 @@ $(document).ready(function () {
           } else {
             $(".submenu-links.show").removeClass("show");
           }
-          return false;
         }
       }
     });

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -34,9 +34,9 @@ $(document).ready(function () {
         var sidebarLink = $(".sidebar a[href='#" + $(this).attr("id") + "']");
         $(".sidebar a.active").removeClass("active");
         sidebarLink.addClass("active");
-        var hasClass = sidebarLink.hasClass("submenu-link"),
-          nextHasClass = sidebarLink.next().hasClass("submenu-links");
-        if (hasClass || (!hasClass && !nextHasClass)) {
+        var isTerminal = sidebarLink.hasClass("submenu-link");
+        var hasSubmenu = sidebarLink.next().hasClass("submenu-links");
+        if (isTerminal || (!isTerminal && !hasSubmenu)) {
           var parent = sidebarLink.parent(),
             hasClass = parent.hasClass("submenu-links");
           if (hasClass && !parent.hasClass("show")) {

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -37,12 +37,13 @@ $(document).ready(function () {
         var isTerminal = sidebarLink.hasClass("submenu-link");
         var hasSubmenu = sidebarLink.next().hasClass("submenu-links");
         if (isTerminal || (!isTerminal && !hasSubmenu)) {
-          var parent = sidebarLink.parent(),
-            hasClass = parent.hasClass("submenu-links");
-          if (hasClass && !parent.hasClass("show")) {
-            $(".submenu-links.show").removeClass("show");
-            sidebarLink.parents(".submenu-links").addClass("show");
-          } else if (!hasClass) {
+          var parent = sidebarLink.parent();
+          if (parent.hasClass("submenu-links")) {
+            if (!parent.hasClass("show")) {
+              $(".submenu-links.show").removeClass("show");
+              sidebarLink.parents(".submenu-links").addClass("show");
+            }
+          } else {
             $(".submenu-links.show").removeClass("show");
           }
           return false;

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -41,7 +41,7 @@ $(document).ready(function () {
             hasClass = parent.hasClass("submenu-links");
           if (hasClass && !parent.hasClass("show")) {
             $(".submenu-links.show").removeClass("show");
-            parent.addClass("show");
+            sidebarLink.parents(".submenu-links").addClass("show");
           } else if (!hasClass) {
             $(".submenu-links.show").removeClass("show");
           }


### PR DESCRIPTION
Fix #862. 

Commits:
1. Show all accessors instead of the parent only.
The key point is to make visible the entire chain of nested blocks in a menu of 3 or more levels.

2. Rename auxiliary variables so that their meaning becomes clear even without analyzing the HTML layout.

3. Reorganize the "if else" block to make its logic more obvious.

4. Remove the unused `return false;` statement:
    - the function has no other `return` instructions;
    - without a `return` statement, the function returns the value` null`, which plays almost the same role in comparison operations as `false`;
    - the function is called from two places in the code without any interest in its result.