### PR TITLE
Fix the duplicate `block` id on the `Get Started` page

### DIFF
--- a/getStarted.html
+++ b/getStarted.html
@@ -121,7 +121,7 @@
                       <!-- rounded button submenu links go here -->
 
                       <!-- block button submenu links go here -->
-                      <a href="#block" class="block has-children-links">Block buttons</a>
+                      <a href="#block-buttons" class="block has-children-links">Block buttons</a>
                       <div class="submenu-links">
                         <a href="#left-icon-block" class="submenu-link">Block button left</a>
                         <a href="#icon-center-block" class="submenu-link">Block button center</a>
@@ -455,7 +455,7 @@
                 <!-- rounded right icon button class ends here -->
                 <br />
                 <!-- block buttons start here -->
-                <h2 class="display-block" id="block">Block Buttons</h2>
+                <h2 class="display-block" id="block-buttons">Block Buttons</h2>
                 <div class="text">
                   The <code>block-btn</code> class gives you a button whose width takes up the width of the parent element/container.
                   Check below to see examples of how to use it.


### PR DESCRIPTION
Currently the subtitle in "Usage" and the subsection in "Base Icon Button" have the same identifiers. The second identifier is better to change.

![fix-duplicate-id-block](https://user-images.githubusercontent.com/3881568/97092263-f7719200-1642-11eb-9e87-8b41025fede4.png)