### PR TITLE
fix: Replace link to docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
             When you only need to include SButtons’s compiled CSS , you can use
             SButtonCDN.
             <br /><br />
-            <a href="/examples.html" class="sbtn transparent-btn banner-link"
+            <a href="documentation.html" class="sbtn transparent-btn banner-link"
               >Explore the docs</a
             >
           </div>


### PR DESCRIPTION
This PR will replace wrong link in `index.html`.

Closes #993 