### PR TITLE
example URL in Footer fixed

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
           <div class="footer-links">
             <a href="https://github.com/sButtons/sbuttons" target="_blank" title="View on Github"> <i
                 class="fab fa-github"></i> GitHub</a>
-            <a href="https://github.com/sButtons/sbuttons" target="_blank" title="View on Github"> <i
+            <a href="https://sbuttons.github.io/sbuttons/examples.html" target="_blank" title="View on Github"> <i
                 class="fas fa-book"></i> Examples</a>
             <a href="https://github.com/sButtons/sbuttons/issues/new/choose" target="_blank" title="View on Github"> <i
                 class="fas fa-bug"></i> Report A Bug</a>

--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
           <div class="footer-links">
             <a href="https://github.com/sButtons/sbuttons" target="_blank" title="View on Github"> <i
                 class="fab fa-github"></i> GitHub</a>
-            <a href="https://sbuttons.github.io/sbuttons/examples.html" target="_blank" title="View on Github"> <i
+            <a href="https://sbuttons.github.io/sbuttons/examples.html" title="View on Github"> <i
                 class="fas fa-book"></i> Examples</a>
             <a href="https://github.com/sButtons/sbuttons/issues/new/choose" target="_blank" title="View on Github"> <i
                 class="fas fa-bug"></i> Report A Bug</a>


### PR DESCRIPTION
examples URL now opens examples page in new tab.
Issue: #994 