### PR TITLE
Update main.css

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -228,6 +228,8 @@ body {
   background: none;
   margin-left: 90%;
   cursor: pointer;
+  /* "To The Top of Page" button / glyph was hiding beneath the footer. Footer has z-index:12. */
+  z-index: 13;
 }
 .scroll-top i {
   font-size: 35px;


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->
Added z-index property to `.scroll-top` class to prevent "To The Top of Page" button from hiding beneath Footer.
Footer had `z-index:12` so I gave a `z-index:13` to this class.

<!-- Specify the issue it relates to, if any --->
Issue: #1010 
