### PR TITLE
fix sidebar hidden behind footer

### DIFF
--- a/assets/css/footer.css
+++ b/assets/css/footer.css
@@ -9,6 +9,13 @@ footer {
   position: relative;
   z-index: 12;
   min-height: 20vh;
+  transition: all ease-in-out 0.3s;
+}
+
+@media (min-width: 992px) {
+  .footer.with-sidebar {
+    margin-left: calc(100vw / 12 * 3 - 5vw);
+  }
 }
 
 .footer .row {

--- a/documentation.html
+++ b/documentation.html
@@ -321,7 +321,7 @@
   <span class="scroll-top" data-scroll="up" style="display: none;">
     <i class="fa fa-chevron-circle-up" aria-hidden="true"></i>
   </span>
-  <footer class="footer">
+  <footer class="footer with-sidebar">
     <div class="row">
       <div class="col-md-3">
         <div class="footer-desc">

--- a/examples.html
+++ b/examples.html
@@ -124,7 +124,7 @@
   <span class="scroll-top" data-scroll="up" style="display: none">
     <i class="fa fa-chevron-circle-up" aria-hidden="true"></i>
   </span>
-  <footer class="footer">
+  <footer class="footer with-sidebar">
     <div class="row">
       <div class="col-md-3">
         <div class="footer-desc">


### PR DESCRIPTION
Fixed sidebar behind footer. Now the footer has a margin of the same size of the sidebar, so it doesn't overlap.

The animation when the footer resizes it’s not perfect, but I believe that is a good improvement.

Issue: Enhance sidebar behavior when reaching the footer #1012
