### PR TITLE
style: change animation duration for flash button

### DIFF
--- a/dist/sbuttons.css
+++ b/dist/sbuttons.css
@@ -2921,7 +2921,7 @@ a.yellow-btn:active:not(.fill-color-btn) {
 }
 .flash-btn:hover {
   animation-name: flash;
-  animation-duration: 2s;
+  animation-duration: 0.6s;
   animation-timing-function: ease-in-out;
   animation-direction: alternate;
   animation-iteration-count: infinite;
@@ -2930,9 +2930,6 @@ a.yellow-btn:active:not(.fill-color-btn) {
 @keyframes flash {
   0% {
     opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
   }
   100% {
     opacity: 0;

--- a/src/components/animated/_flash.less
+++ b/src/components/animated/_flash.less
@@ -3,7 +3,7 @@
 
   &:hover {
     animation-name: flash;
-    animation-duration: 2s;
+    animation-duration: 0.6s;
     animation-timing-function: ease-in-out;
     animation-direction: alternate;
     animation-iteration-count: infinite;
@@ -14,10 +14,6 @@
 @keyframes flash {
   0% {
     opacity: 1;
-  }
-
-  50% {
-    opacity: 0.5;
   }
 
   100% {


### PR DESCRIPTION
closes #1019

I think 0.6s is the best option. I made a gif for other speeds I have tested as well:

0.5s
![0 5s](https://user-images.githubusercontent.com/7880548/97767677-6e53d280-1afc-11eb-923b-4778ed7b0361.gif)

0.6s
![0 6s](https://user-images.githubusercontent.com/7880548/97767679-701d9600-1afc-11eb-9684-292a8419ed69.gif)

0.8s
![0 8s](https://user-images.githubusercontent.com/7880548/97767682-714ec300-1afc-11eb-812c-fb180a4829e6.gif)

1s
![1s](https://user-images.githubusercontent.com/7880548/97767684-73188680-1afc-11eb-85c3-81d04cbb114a.gif)