### PR TITLE
fixed overlapping of text in mobile view

### DIFF
--- a/assets/css/documentation.css
+++ b/assets/css/documentation.css
@@ -3,14 +3,14 @@ section {
   margin-top: -80px;
 }
 
-@media screen and (max-width: 600px){
+@media screen and (max-width: 400px){
 .main-head{
   padding-bottom: 18em ;
 }}
 
-@media screen and (min-width: 601px) and (max-width: 730px){
+@media screen and (min-width: 401px) and (max-width: 730px){
 .main-head{
-  padding-bottom: 15em ;
+  padding-bottom: 13em ;
 }}
 
 .text {

--- a/assets/css/documentation.css
+++ b/assets/css/documentation.css
@@ -3,6 +3,11 @@ section {
   margin-top: -80px;
 }
 
+@media screen and (max-width: 600px){
+.main-head{
+  padding-bottom: 18em ;
+}}
+
 .text {
   font-size: 1rem;
   color: black;

--- a/assets/css/documentation.css
+++ b/assets/css/documentation.css
@@ -8,6 +8,11 @@ section {
   padding-bottom: 18em ;
 }}
 
+@media screen and (min-width: 601px) and (max-width: 730px){
+.main-head{
+  padding-bottom: 15em ;
+}}
+
 .text {
   font-size: 1rem;
   color: black;

--- a/assets/css/examples.css
+++ b/assets/css/examples.css
@@ -3,6 +3,11 @@ section {
   margin-top: -80px;
 }
 
+@media screen and (max-width: 600px){
+.main-head{
+  padding-bottom: 18em ;
+}}
+
 .button-grid {
   display: flex;
   flex-wrap: wrap;

--- a/assets/css/examples.css
+++ b/assets/css/examples.css
@@ -8,6 +8,11 @@ section {
   padding-bottom: 18em ;
 }}
 
+@media screen and (min-width: 601px) and (max-width: 790px){
+.main-head{
+  padding-bottom: 15em ;
+}}
+
 .button-grid {
   display: flex;
   flex-wrap: wrap;

--- a/assets/css/examples.css
+++ b/assets/css/examples.css
@@ -3,14 +3,14 @@ section {
   margin-top: -80px;
 }
 
-@media screen and (max-width: 600px){
+@media screen and (max-width: 442px){
 .main-head{
   padding-bottom: 18em ;
 }}
 
-@media screen and (min-width: 601px) and (max-width: 790px){
+@media screen and (min-width: 443px) and (max-width: 790px){
 .main-head{
-  padding-bottom: 15em ;
+  padding-bottom: 13em ;
 }}
 
 .button-grid {


### PR DESCRIPTION
fixes: #1006
The overlapping of text in examples and documentation pages in mobile view has been fixed.
