### PR TITLE
Reduced margin below extra-large buttons

### DIFF
--- a/assets/css/examples.css
+++ b/assets/css/examples.css
@@ -27,6 +27,10 @@ section {
 }
 
 .button-container .sbtn {
+  margin-bottom: 1em;
+}
+
+.button-container .xlarge-btn {
   margin-bottom: 0.15em;
 }
 

--- a/assets/css/examples.css
+++ b/assets/css/examples.css
@@ -27,7 +27,7 @@ section {
 }
 
 .button-container .sbtn {
-  margin-bottom: 1em;
+  margin-bottom: 0.15em;
 }
 
 #hinge .button-container .block-btn {


### PR DESCRIPTION
Reduced margin below extra-large buttons to make visual grouping more obvious.

<!-- Specify the issue it relates to, if any --->
Issue: https://github.com/sButtons/sbuttons/issues/1020