### PR TITLE
Feat: add animated class to atom button

### DIFF
--- a/dist/sbuttons.css
+++ b/dist/sbuttons.css
@@ -3204,6 +3204,20 @@ a.yellow-btn:active:not(.fill-color-btn) {
 .atom-btn.white-btn::after {
   border-color: #e9e9e9;
 }
+.atom-btn.animated::after {
+  background: white;
+  content: "";
+  position: absolute;
+  height: 14px;
+  width: 14px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  border-width: 4px;
+  border-style: solid;
+  display: none;
+  display: inline-block;
+  animation: atom 2s infinite linear;
+}
 .atom-btn::after {
   background: white;
   content: "";

--- a/src/components/animated/_atom.less
+++ b/src/components/animated/_atom.less
@@ -7,6 +7,24 @@
   }
 }
 
+.animationObjectRule() {
+  background: white;
+  content: "";
+  position: absolute;
+  height: 14px;
+  width: 14px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  border-width: 4px;
+  border-style: solid;
+  display: none;
+}
+
+.animationRule() {
+  display: inline-block;
+  animation: atom 2s infinite linear;
+}
+
 .atom-btn {
   border: 4px solid;
   background-color: transparent;
@@ -17,6 +35,7 @@
   &.blue-btn {
     .outlineRule(@blue);
   }
+
   &.pink-btn {
     .outlineRule(@pink);
   }
@@ -50,22 +69,20 @@
     color: @darkText !important;
   }
 
-  &::after {
-    background: white;
-    content: "";
-    position: absolute;
-    height: 14px;
-    width: 14px;
-    border-radius: 50%;
-    transform: translate(-50%, -50%);
-    border-width: 4px;
-    border-style: solid;
-    display: none;
+  &.animated {
+    &::after {
+      .animationObjectRule();
+      .animationRule();
+    }
   }
+
+  &::after {
+    .animationObjectRule();
+  }
+
   &:hover::after,
   &:focus::after {
-    display: inline-block;
-    animation: atom 2s infinite linear;
+    .animationRule();
   }
 
   @keyframes atom {


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->

<!-- Specify the issue it relates to, if any --->
Issue: #1022 - atom button

Adds `.animated` class with continuous loop of the existing hover animation.

Demo with `.animated` added to blue button:
![atom-buttons-animated-class](https://user-images.githubusercontent.com/39736230/97791732-f349f500-1bab-11eb-8e74-7d88fbac6d45.gif)
