### PR TITLE
Link to the example page rather than then the home page from Documentation page and remove target blank because a new tab should not be opened

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -244,7 +244,7 @@
           </div>
           <div class="text">
             You can find all classes and their corresponding sButtons mentioned in our <a
-              href="https://sbuttons.github.io/sbuttons/examples.html">website</a>.
+              href="https://sbuttons.github.io/sbuttons/examples.html">Examples page</a>.
           </div>
 
         </section>

--- a/documentation.html
+++ b/documentation.html
@@ -138,7 +138,7 @@
           <h2>Download CSS File</h2>
           <div class="text">
             You can download the CSS file
-            <a href="#" id="downloadGithubRawHowTo" class="cssLink" target="blank">here</a> and then add it to your
+            <a href="#" id="downloadGithubRawHowTo" class="cssLink">here</a> and then add it to your
             html file in between the tags.
           </div>
           <div class="text">
@@ -244,7 +244,7 @@
           </div>
           <div class="text">
             You can find all classes and their corresponding sButtons mentioned in our <a
-              href="https://sButtons.github.io/sbuttons/">website</a>.
+              href="https://sbuttons.github.io/sbuttons/examples.html">website</a>.
           </div>
 
         </section>


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->

<!-- Specify the issue it relates to, if any --->
Issue:
