### PR TITLE
 SButtonCDN to sButtons CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
         </div>
         <div class="instruction row">
           <div class="desc col col-md-6 col-sm-12">
-            Install sButttons’s source LESS via npm.
+            Install sButtons’s source LESS via npm.
             <br /><br />
             Package managed installs don’t include documentation or our full
             build scripts. You can also use our npm.
@@ -177,7 +177,7 @@
         <div class="instruction row">
           <div class="desc col col-md-6 col-sm-12">
             When you only need to include sButtons’s compiled CSS , you can use
-            SButtonCDN.
+            sButtons CDN.
             <br /><br />
             <a
               href="documentation.html"
@@ -187,7 +187,7 @@
           </div>
           <div class="code col col-md-6 col-sm-12">
             <div class="script-copy">
-              <pre><code class="language-markup"> &lt;link rel="stylesheet" href="https://cdn.statically.io/gh/sButtons/sbuttons/c135f5f7/dist/sbuttons.min.css"></code></pre>
+              <pre><code class="language-markup"> &lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/sbuttons/sbuttons/dist/sbuttons.css"></code></pre>
               <div class="div-copy"><button class="clipboard"></button></div>
             </div>
           </div>


### PR DESCRIPTION
 1. SButtonCDN to sButtons CDN 
 2. Link Updated 
 3. A typo in Installation section corrected.


 

