### PR TITLE
Fix #1018. Improve the "Next" and "Previous" buttons

### DIFF
--- a/dist/sbuttons.css
+++ b/dist/sbuttons.css
@@ -18,6 +18,8 @@
 /* END VARIABLES IN special/_toggle.less */
 /* BEGIN VARIABLES IN special/_gradient.less */
 /* END VARIABLES IN special/_gradient.less */
+/* BEGIN VARIABLES IN special/_arrow.less */
+/* END VARIABLES IN special/_arrow.less */
 .sbtn {
   padding: 10px;
   text-align: center;
@@ -1702,67 +1704,23 @@ a.yellow-btn:active:not(.fill-color-btn) {
 }
 .next-arrow-btn:after {
   content: "\203A";
-  padding-left: 0.5em;
-  position: absolute;
-  color: #fff;
-  height: 100%;
-  top: -1px;
-  display: flex;
+  padding-right: 0.5em;
+  right: -1.5em;
   align-items: center;
+  color: inherit;
+  display: flex;
   font-size: 1.5rem;
-  transform: rotateY(90deg);
-}
-.next-arrow-btn:not(.rounded-btn):after {
-  right: 0.5em;
-  transition: all 0.05s;
-}
-.next-arrow-btn.rounded-btn {
-  transition: padding-right 0.1s;
-}
-.next-arrow-btn.rounded-btn:after {
-  right: 11px;
-  border-radius: 50%;
-  transition: all 0.05s;
+  height: 100%;
+  position: absolute;
+  top: -1px;
+  transition: inherit;
 }
 .next-arrow-btn:hover {
   padding-right: 1.5em;
 }
 .next-arrow-btn:hover:after {
-  transform: rotateY(0);
-}
-.next-arrow-btn.blue-btn:after {
-  background-color: #50bfe6;
-  border: 1px solid #50bfe6;
-}
-.next-arrow-btn.pink-btn:after {
-  background-color: #d53caf;
-  border: 1px solid #d53caf;
-}
-.next-arrow-btn.green-btn:after {
-  background-color: #3aa655;
-  border: 1px solid #3aa655;
-}
-.next-arrow-btn.yellow-btn:after {
-  background-color: #fbe870;
-  border: 1px solid #fbe870;
-  color: #333 !important;
-}
-.next-arrow-btn.orange-btn:after {
-  background-color: #ff8833;
-  border: 1px solid #ff8833;
-}
-.next-arrow-btn.red-btn:after {
-  background-color: #ed0a3f;
-  border: 1px solid #ed0a3f;
-}
-.next-arrow-btn.purple-btn:after {
-  background-color: #652dc1;
-  border: 1px solid #652dc1;
-}
-.next-arrow-btn.white-btn:after {
-  background-color: #fff;
-  border: 1px solid #fff;
-  color: #333 !important;
+  opacity: 1;
+  right: 0;
 }
 .previous-arrow-btn {
   position: relative;
@@ -1770,67 +1728,23 @@ a.yellow-btn:active:not(.fill-color-btn) {
 }
 .previous-arrow-btn:before {
   content: "\2039";
-  padding-right: 0.5em;
-  position: absolute;
-  color: #fff;
-  height: 100%;
-  top: -1px;
-  display: flex;
+  left: -1.5em;
+  padding-left: 0.5em;
   align-items: center;
+  color: inherit;
+  display: flex;
   font-size: 1.5rem;
-  transform: rotateY(90deg);
-}
-.previous-arrow-btn:not(.rounded-btn):before {
-  left: 0.5em;
-  transition: all 0.05s;
-}
-.previous-arrow-btn.rounded-btn {
-  transition: padding-left 0.1s;
-}
-.previous-arrow-btn.rounded-btn:before {
-  left: 11px;
-  border-radius: 50%;
-  transition: all 0.05s;
+  height: 100%;
+  position: absolute;
+  top: -1px;
+  transition: inherit;
 }
 .previous-arrow-btn:hover {
   padding-left: 1.5em;
 }
 .previous-arrow-btn:hover:before {
-  transform: rotateY(0);
-}
-.previous-arrow-btn.blue-btn:before {
-  background-color: #50bfe6;
-  border: 1px solid #50bfe6;
-}
-.previous-arrow-btn.pink-btn:before {
-  background-color: #d53caf;
-  border: 1px solid #d53caf;
-}
-.previous-arrow-btn.green-btn:before {
-  background-color: #3aa655;
-  border: 1px solid #3aa655;
-}
-.previous-arrow-btn.yellow-btn:before {
-  background-color: #fbe870;
-  border: 1px solid #fbe870;
-  color: #333 !important;
-}
-.previous-arrow-btn.orange-btn:before {
-  background-color: #ff8833;
-  border: 1px solid #ff8833;
-}
-.previous-arrow-btn.red-btn:before {
-  background-color: #ed0a3f;
-  border: 1px solid #ed0a3f;
-}
-.previous-arrow-btn.purple-btn:before {
-  background-color: #652dc1;
-  border: 1px solid #652dc1;
-}
-.previous-arrow-btn.white-btn:before {
-  background-color: #fff;
-  border: 1px solid #fff;
-  color: #333 !important;
+  left: 0;
+  opacity: 1;
 }
 .aurapulse-btn {
   position: relative;
@@ -3674,14 +3588,6 @@ a.yellow-btn:active:not(.fill-color-btn) {
 .social-btn.snapchat:after {
   color: #353535;
   content: "\f2ac";
-}
-.social-btn.steam {
-  background-color: #202329;
-  color: #fff;
-}
-.social-btn.steam:after {
-  color: #fff;
-  content: "\f1b6";
 }
 .social-btn.microsoft {
   background-color: #00acee;

--- a/src/_variables.less
+++ b/src/_variables.less
@@ -138,3 +138,8 @@
 @boxShadowWhite: #aca6a6;
 @boxShadowYellow: #e2e22e;
 /* END VARIABLES IN special/_gradient.less */
+
+/* BEGIN VARIABLES IN special/_arrow.less */
+@arrowExpansion: 1.5em;
+@arrowPadding: 0.5em;
+/* END VARIABLES IN special/_arrow.less */

--- a/src/components/animated/_arrow.less
+++ b/src/components/animated/_arrow.less
@@ -1,45 +1,12 @@
 .arrowRules() {
-  position: absolute;
-  color: @lightText;
-  height: 100%;
-  top: -1px;
-  display: flex;
   align-items: center;
+  color: inherit;
+  display: flex;
   font-size: 1.5rem;
-  transform: rotateY(90deg);
-}
-
-.arrowColorRules(@position) {
-  .after(@color) {
-    .bc(@color);
-    border: 1px solid @color;
-  }
-  &.blue-btn:@{position} {
-    .after(@blue);
-  }
-  &.pink-btn:@{position} {
-    .after(@pink);
-  }
-  &.green-btn:@{position} {
-    .after(@green);
-  }
-  &.yellow-btn:@{position} {
-    .after(@yellow);
-    color: @darkText !important;
-  }
-  &.orange-btn:@{position} {
-    .after(@orange);
-  }
-  &.red-btn:@{position} {
-    .after(@red);
-  }
-  &.purple-btn:@{position} {
-    .after(@purple);
-  }
-  &.white-btn:@{position} {
-    .after(@white);
-    color: @darkText !important;
-  }
+  height: 100%;
+  position: absolute;
+  top: -1px;
+  transition: inherit;
 }
 
 .next-arrow-btn {
@@ -48,67 +15,36 @@
 
   &:after {
     content: "\203A";
-    padding-left: 0.5em;
+    padding-right: @arrowPadding;
+    right: -@arrowExpansion;
     .arrowRules();
   }
 
-  &:not(.rounded-btn) {
-    &:after {
-      right: 0.5em;
-      transition: all 0.05s;
-    }
-  }
-
-  &.rounded-btn {
-    transition: padding-right 0.1s;
-    &:after {
-      right: 11px;
-      border-radius: 50%;
-      transition: all 0.05s;
-    }
-  }
-
   &:hover {
-    padding-right: 1.5em;
+    padding-right: @arrowExpansion;
     &:after {
-      transform: rotateY(0);
+      opacity: 1;
+      right: 0;
     }
   }
-
-  .arrowColorRules(after);
 }
 
 .previous-arrow-btn {
   position: relative;
   transition: all 0.1s;
+
   &:before {
     content: "\2039";
-    padding-right: 0.5em;
+    left: -@arrowExpansion;
+    padding-left: @arrowPadding;
     .arrowRules();
   }
 
-  &:not(.rounded-btn) {
-    &:before {
-      left: 0.5em;
-      transition: all 0.05s;
-    }
-  }
-
-  &.rounded-btn {
-    transition: padding-left 0.1s;
-    &:before {
-      left: 11px;
-      border-radius: 50%;
-      transition: all 0.05s;
-    }
-  }
-
   &:hover {
-    padding-left: 1.5em;
+    padding-left: @arrowExpansion;
     &:before {
-      transform: rotateY(0);
+      left: 0;
+      opacity: 1;
     }
   }
-
-  .arrowColorRules(before);
 }


### PR DESCRIPTION
Fix #1018

1. Currently the arrow on the button appears using the `rotateY` transformation. Perhaps this is precisely why a strange vertical line appeared on the screenshot [in the issue description](https://github.com/sButtons/sbuttons/issues/1018). I've used the `opacity` property instead. It has fewer pitfalls.

2. Noticed that the edge of the word on the button blinks on hover. This is because the pseudo-element with an arrow first covers a part of the word, and then moves to the side. To fix this, I placed the pseudo element outside of the button. There it is invisible thanks to the `overflow` property of the button. Now on hover the button becomes wider and the arrow drives inward.

![next-hover](https://user-images.githubusercontent.com/3881568/98426625-d9238180-2099-11eb-909d-8a4364ace262.png)

3. Removed a large piece of code regarding the background, color and shape of the pseudo-elements. The background and shape may simply be absent, and only the color of the arrow is important. But it is enough to use the `inherit` value to get the actual color of the button.

4. There is no need for special code for the rounded button too.

5. Added two constants for the indentation of these buttons.

6. Updated the code for the `Previous` button in the same way.

What needs to be improved? What have I not taken into account?