### PR TITLE
Add Dark Mode Support for Diagonal Background, Fill, and Ripple

### DIFF
--- a/dist/sbuttons.css
+++ b/dist/sbuttons.css
@@ -1952,13 +1952,11 @@ a.yellow-btn:active:not(.fill-color-btn) {
 }
 [data-theme="dark"] .diag-btn.black-btn.black-btn,
 .diag-btn.black-btn.black-btn.dark-mode {
-  color: #000 !important;
-  text-shadow: 2px 2px #333333;
+  color: white !important;
 }
 @media (prefers-color-scheme: dark) {
   .diag-btn.black-btn.black-btn {
-    color: #000 !important;
-    text-shadow: 2px 2px #333333;
+    color: white !important;
   }
 }
 .diag-btn.white-btn {
@@ -2089,8 +2087,6 @@ a.yellow-btn:active:not(.fill-color-btn) {
 .fill-color-btn:hover,
 .fill-color-btn.animated {
   color: #fff !important;
-  height: 3.62rem;
-  border: 0rem;
 }
 .fill-color-btn.sideways-fill:before {
   width: 100%;
@@ -2201,13 +2197,11 @@ a.yellow-btn:active:not(.fill-color-btn) {
 }
 [data-theme="dark"] .fill-color-btn.black-btn.black-btn,
 .fill-color-btn.black-btn.black-btn.dark-mode {
-  color: #000;
-  text-shadow: 2px 2px #333333;
+  color: white !important;
 }
 @media (prefers-color-scheme: dark) {
   .fill-color-btn.black-btn.black-btn {
-    color: #000;
-    text-shadow: 2px 2px #333333;
+    color: white !important;
   }
 }
 .fill-color-btn.black-btn:before {
@@ -2245,10 +2239,6 @@ a.yellow-btn:active:not(.fill-color-btn) {
 .fill-color-btn.white-btn:hover,
 .fill-color-btn.white-btn.animated {
   color: #333 !important;
-}
-.fill-color-btn:not(.block-btn):hover,
-.fill-color-btn.animated:not(.block-btn) {
-  width: 5.6rem;
 }
 .hinge-btn {
   transition: transform 0.2s;
@@ -2622,13 +2612,11 @@ a.yellow-btn:active:not(.fill-color-btn) {
 }
 [data-theme="dark"] .ripple-btn.black-btn.black-btn,
 .ripple-btn.black-btn.black-btn.dark-mode {
-  color: #000;
-  text-shadow: 2px 2px #333333;
+  color: white !important;
 }
 @media (prefers-color-scheme: dark) {
   .ripple-btn.black-btn.black-btn {
-    color: #000;
-    text-shadow: 2px 2px #333333;
+    color: white !important;
   }
 }
 .ripple-btn.black-btn::before {

--- a/dist/sbuttons.css
+++ b/dist/sbuttons.css
@@ -1950,12 +1950,35 @@ a.yellow-btn:active:not(.fill-color-btn) {
   ) !important;
   color: #333 !important;
 }
+[data-theme="dark"] .diag-btn.black-btn.black-btn,
+.diag-btn.black-btn.black-btn.dark-mode {
+  color: #000 !important;
+  text-shadow: 2px 2px #333333;
+}
+@media (prefers-color-scheme: dark) {
+  .diag-btn.black-btn.black-btn {
+    color: #000 !important;
+    text-shadow: 2px 2px #333333;
+  }
+}
 .diag-btn.white-btn {
   background-image: linear-gradient(
     120deg,
     transparent 50%,
     #fff 50%
   ) !important;
+  color: #333 !important;
+}
+[data-theme="dark"] .diag-btn.white-btn.white-btn,
+.diag-btn.white-btn.white-btn.dark-mode {
+  color: white !important;
+}
+@media (prefers-color-scheme: dark) {
+  .diag-btn.white-btn.white-btn {
+    color: white !important;
+  }
+}
+.diag-btn.white-btn.white-btn:hover {
   color: #333 !important;
 }
 .diag-btn.white-btn:hover {
@@ -2176,6 +2199,17 @@ a.yellow-btn:active:not(.fill-color-btn) {
   border-color: #000 !important;
   color: #000;
 }
+[data-theme="dark"] .fill-color-btn.black-btn.black-btn,
+.fill-color-btn.black-btn.black-btn.dark-mode {
+  color: #000;
+  text-shadow: 2px 2px #333333;
+}
+@media (prefers-color-scheme: dark) {
+  .fill-color-btn.black-btn.black-btn {
+    color: #000;
+    text-shadow: 2px 2px #333333;
+  }
+}
 .fill-color-btn.black-btn:before {
   background-color: #000;
 }
@@ -2188,6 +2222,18 @@ a.yellow-btn:active:not(.fill-color-btn) {
   color: #fff;
   border-color: #e9e9e9 !important;
   color: #333;
+}
+[data-theme="dark"] .fill-color-btn.white-btn.white-btn,
+.fill-color-btn.white-btn.white-btn.dark-mode {
+  color: white !important;
+}
+@media (prefers-color-scheme: dark) {
+  .fill-color-btn.white-btn.white-btn {
+    color: white !important;
+  }
+}
+.fill-color-btn.white-btn.white-btn:hover {
+  color: #333 !important;
 }
 .fill-color-btn.white-btn:before {
   background-color: #fff;
@@ -2574,6 +2620,17 @@ a.yellow-btn:active:not(.fill-color-btn) {
   border-color: #000;
   color: #000;
 }
+[data-theme="dark"] .ripple-btn.black-btn.black-btn,
+.ripple-btn.black-btn.black-btn.dark-mode {
+  color: #000;
+  text-shadow: 2px 2px #333333;
+}
+@media (prefers-color-scheme: dark) {
+  .ripple-btn.black-btn.black-btn {
+    color: #000;
+    text-shadow: 2px 2px #333333;
+  }
+}
 .ripple-btn.black-btn::before {
   background-color: #000;
 }
@@ -2581,6 +2638,18 @@ a.yellow-btn:active:not(.fill-color-btn) {
   border-color: #fff;
   color: #fff;
   border-color: #e9e9e9;
+}
+[data-theme="dark"] .ripple-btn.white-btn.white-btn,
+.ripple-btn.white-btn.white-btn.dark-mode {
+  color: white !important;
+}
+@media (prefers-color-scheme: dark) {
+  .ripple-btn.white-btn.white-btn {
+    color: white !important;
+  }
+}
+.ripple-btn.white-btn.white-btn:hover {
+  color: #333 !important;
 }
 .ripple-btn.white-btn::before {
   background-color: #fff;

--- a/src/components/_basic.less
+++ b/src/components/_basic.less
@@ -32,12 +32,10 @@
   &.black-btn {
     [data-theme="dark"] &,
     &.dark-mode {
-      color: #000;
-      text-shadow: 2px 2px #333333;
+      color: white !important;
     }
     @media (prefers-color-scheme: dark) {
-      color: #000;
-      text-shadow: 2px 2px #333333;
+      color: white !important;
     }
   }
 }

--- a/src/components/_basic.less
+++ b/src/components/_basic.less
@@ -12,6 +12,36 @@
   }
 }
 
+.whiteBtnDarkMode() {
+  &.white-btn {
+    [data-theme="dark"] &,
+    &.dark-mode {
+      color: white !important;
+    }
+    @media (prefers-color-scheme: dark) {
+      color: white !important;
+    }
+
+    &:hover {
+      color: @darkText !important;
+    }
+  }
+}
+
+.blackBtnDarkMode() {
+  &.black-btn {
+    [data-theme="dark"] &,
+    &.dark-mode {
+      color: #000;
+      text-shadow: 2px 2px #333333;
+    }
+    @media (prefers-color-scheme: dark) {
+      color: #000;
+      text-shadow: 2px 2px #333333;
+    }
+  }
+}
+
 .sbtn {
   padding: @buttonPadding;
   text-align: center;

--- a/src/components/animated/_diagonalBackground.less
+++ b/src/components/animated/_diagonalBackground.less
@@ -15,6 +15,20 @@
   transform: translateX(16px);
 }
 
+.diagonalBlackDarkMode() {
+  &.black-btn {
+    [data-theme="dark"] &,
+    &.dark-mode {
+      color: #000 !important;
+      text-shadow: 2px 2px #333333;
+    }
+    @media (prefers-color-scheme: dark) {
+      color: #000 !important;
+      text-shadow: 2px 2px #333333;
+    }
+  }
+}
+
 .diag-btn {
   text-decoration: none;
   display: inline-block;
@@ -58,10 +72,12 @@
   }
 
   &.black-btn {
+    .diagonalBlackDarkMode();
     .diagonalBackground(@darkText, @black);
   }
 
   &.white-btn {
+    .whiteBtnDarkMode();
     .diagonalBackground(@darkText, @white);
 
     &:hover {

--- a/src/components/animated/_diagonalBackground.less
+++ b/src/components/animated/_diagonalBackground.less
@@ -15,20 +15,6 @@
   transform: translateX(16px);
 }
 
-.diagonalBlackDarkMode() {
-  &.black-btn {
-    [data-theme="dark"] &,
-    &.dark-mode {
-      color: #000 !important;
-      text-shadow: 2px 2px #333333;
-    }
-    @media (prefers-color-scheme: dark) {
-      color: #000 !important;
-      text-shadow: 2px 2px #333333;
-    }
-  }
-}
-
 .diag-btn {
   text-decoration: none;
   display: inline-block;
@@ -72,7 +58,7 @@
   }
 
   &.black-btn {
-    .diagonalBlackDarkMode();
+    .blackBtnDarkMode();
     .diagonalBackground(@darkText, @black);
   }
 

--- a/src/components/animated/_fill.less
+++ b/src/components/animated/_fill.less
@@ -101,8 +101,6 @@
   &:hover,
   &.animated {
     color: #fff !important;
-    height: 3.62rem;
-    border: 0rem;
   }
 
   &.sideways-fill {
@@ -195,10 +193,5 @@
     &.animated {
       color: @darkText !important;
     }
-  }
-
-  &:not(.block-btn):hover,
-  &.animated:not(.block-btn) {
-    width: 5.6rem;
   }
 }

--- a/src/components/animated/_fill.less
+++ b/src/components/animated/_fill.less
@@ -182,10 +182,12 @@
   }
 
   &.black-btn {
+    .blackBtnDarkMode();
     .colorBtn(@black);
   }
 
   &.white-btn {
+    .whiteBtnDarkMode();
     .colorBtn(@white);
     border-color: @whiteBorder !important;
     color: @darkText;

--- a/src/components/animated/_ripple.less
+++ b/src/components/animated/_ripple.less
@@ -64,10 +64,14 @@
   }
 
   &.black-btn {
+    .blackBtnDarkMode();
+
     .rippleBtn(@black);
   }
 
   &.white-btn {
+    .whiteBtnDarkMode();
+
     .rippleBtn(@white);
     border-color: @whiteBorder;
     &:hover {


### PR DESCRIPTION
Issue: #1014 

Please see the demo below. The solution I found for black-btn is to add a grey shadow so that it stands out a bit more than just plain black color. Please let me know if you have a better idea.
![diag](https://user-images.githubusercontent.com/34357020/99036922-a0c7eb80-2550-11eb-9ce5-f193b201b74d.gif)
![fill](https://user-images.githubusercontent.com/34357020/99036926-a291af00-2550-11eb-9021-14ed8d7144f4.gif)
![ripple](https://user-images.githubusercontent.com/34357020/99036928-a3c2dc00-2550-11eb-82c3-7867bd6a43a0.gif)


