### PR TITLE
Fixing buttons that have more than 3 classes

### DIFF
--- a/assets/js/buttons-examples.js
+++ b/assets/js/buttons-examples.js
@@ -808,9 +808,9 @@ $(document).ready(function () {
         }
         // add normal button grid for button
         let newText = (totalWrittenClasses.split(" "));
-        if(newText.length > 3)
+        if(newText.length >=4)
         {
-          for(let i=2;i<newText.length;i++)
+          for(let i=3;i<newText.length;i++)
           {
             newText[i]= '.'+newText[i];
 

--- a/assets/js/buttons-examples.js
+++ b/assets/js/buttons-examples.js
@@ -807,16 +807,13 @@ $(document).ready(function () {
           totalWrittenClasses += ` .${thisButtonClasses}`;
         }
         // add normal button grid for button
-        let newText = totalWrittenClasses.split(" ").filter(x => x.length > 0);
-        if(newText.length >=4)
-        {
+         let newText = totalWrittenClasses.split(" ").filter(x => x.length > 0);
           for(let i=0;i<newText.length;i++)
           {
-            if(newText[i][0]!='.')
-               newText[i]= '.'+newText[i];
+              if(newText[i][0]!='.')
+                newText[i]= '.'+newText[i];
           }
-          totalWrittenClasses =newText.join(" ");
-        }
+        totalWrittenClasses =newText.join(" ");
         normalButtonsGrid.append(
           getButtonHtml(
             totalClasses,

--- a/assets/js/buttons-examples.js
+++ b/assets/js/buttons-examples.js
@@ -807,6 +807,16 @@ $(document).ready(function () {
           totalWrittenClasses += ` .${thisButtonClasses}`;
         }
         // add normal button grid for button
+        let newText = (totalWrittenClasses.split(" "));
+        if(newText.length > 3)
+        {
+          for(let i=2;i<newText.length;i++)
+          {
+            newText[i]= '.'+newText[i];
+
+          }
+          totalWrittenClasses =newText.join(" ");
+        }
         normalButtonsGrid.append(
           getButtonHtml(
             totalClasses,

--- a/assets/js/buttons-examples.js
+++ b/assets/js/buttons-examples.js
@@ -804,16 +804,9 @@ $(document).ready(function () {
           totalWrittenClasses = `.${defaultClass} .${button.classes}`;
         if (thisButtonClasses.length) {
           totalClasses += ` ${thisButtonClasses}`;
-          totalWrittenClasses += ` .${thisButtonClasses}`;
+          totalWrittenClasses += ` .${thisButtonClasses.replace(/\s\s/g," ").replace(/\s/g , " .")}`;
         }
         // add normal button grid for button
-         let newText = totalWrittenClasses.split(" ").filter(x => x.length > 0);
-          for(let i=0;i<newText.length;i++)
-          {
-              if(newText[i][0]!='.')
-                newText[i]= '.'+newText[i];
-          }
-        totalWrittenClasses =newText.join(" ");
         normalButtonsGrid.append(
           getButtonHtml(
             totalClasses,

--- a/assets/js/buttons-examples.js
+++ b/assets/js/buttons-examples.js
@@ -810,10 +810,10 @@ $(document).ready(function () {
         let newText = totalWrittenClasses.split(" ").filter(x => x.length > 0);
         if(newText.length >=4)
         {
-          console.log(newText)
-          for(let i=3;i<newText.length;i++)
+          for(let i=0;i<newText.length;i++)
           {
-            newText[i]= '.'+newText[i];
+            if(newText[i][0]!='.')
+               newText[i]= '.'+newText[i];
           }
           totalWrittenClasses =newText.join(" ");
         }

--- a/assets/js/buttons-examples.js
+++ b/assets/js/buttons-examples.js
@@ -804,7 +804,7 @@ $(document).ready(function () {
           totalWrittenClasses = `.${defaultClass} .${button.classes}`;
         if (thisButtonClasses.length) {
           totalClasses += ` ${thisButtonClasses}`;
-          totalWrittenClasses += ` .${thisButtonClasses.replace(/\s\s/g," ").replace(/\s/g , " .")}`;
+          totalWrittenClasses += ` .${thisButtonClasses.replace(/\s+/g,' .')}`;
         }
         // add normal button grid for button
         normalButtonsGrid.append(

--- a/assets/js/buttons-examples.js
+++ b/assets/js/buttons-examples.js
@@ -807,13 +807,13 @@ $(document).ready(function () {
           totalWrittenClasses += ` .${thisButtonClasses}`;
         }
         // add normal button grid for button
-        let newText = (totalWrittenClasses.split(" "));
+        let newText = totalWrittenClasses.split(" ").filter(x => x.length > 0);
         if(newText.length >=4)
         {
+          console.log(newText)
           for(let i=3;i<newText.length;i++)
           {
             newText[i]= '.'+newText[i];
-
           }
           totalWrittenClasses =newText.join(" ");
         }


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->

<!-- Specify the issue it relates to, if any --->
Issue:
Buttons that had 3 or more classes weren't displayed correctly.
Each button should be preceded with a `.` but buttons that have more than 3 classes only has a `.` before the first three class names.