### PR TITLE
Add dark mode support for base icon

### DIFF
--- a/dist/sbuttons.css
+++ b/dist/sbuttons.css
@@ -3868,6 +3868,10 @@ a.yellow-btn:active:not(.fill-color-btn) {
 .icon-btn {
   color: #000;
 }
+[data-theme="dark"] .icon-btn,
+.icon-btn.dark-mode {
+  color: #fff;
+}
 .icon-btn i {
   text-align: center;
 }

--- a/src/components/icon/_icon-btn.less
+++ b/src/components/icon/_icon-btn.less
@@ -3,9 +3,7 @@
 
   [data-theme="dark"] &,
   &.dark-mode {
-    & {
-      color: @white;
-    }
+    color: @white;
   }
 
   & i {

--- a/src/components/icon/_icon-btn.less
+++ b/src/components/icon/_icon-btn.less
@@ -1,6 +1,13 @@
 .icon-btn {
   color: @black;
 
+  [data-theme="dark"] &,
+  &.dark-mode {
+    & {
+      color: @white;
+    }
+  }
+
   & i {
     text-align: center;
   }


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->
Dark mode handling was added to Base Icon with transparent background.

Light mode:
![Light mode Base Icon](https://user-images.githubusercontent.com/17826623/101551073-bb0ab300-39b0-11eb-856d-764aaa793497.png)

Dark mode:
![Dark mode Base Icon](https://user-images.githubusercontent.com/17826623/101551178-ebeae800-39b0-11eb-8a27-099b68d540e2.png)

<!-- Specify the issue it relates to, if any --->
Issue: #1014 
