### PR TITLE
Text padding

### DIFF
--- a/assets/css/documentation.css
+++ b/assets/css/documentation.css
@@ -22,6 +22,14 @@ section {
   font-family: "Syne", sans-serif;
 }
 
+.text-under-button {
+  font-size: 1rem;
+  color: black;
+  word-wrap: break-word;
+  font-family: "Syne", sans-serif;
+  padding-top: 1em;
+}
+
 .code-text {
   font-family: monospace;
 }

--- a/assets/css/documentation.css
+++ b/assets/css/documentation.css
@@ -23,10 +23,6 @@ section {
 }
 
 .text-under-button {
-  font-size: 1rem;
-  color: black;
-  word-wrap: break-word;
-  font-family: "Syne", sans-serif;
   padding-top: 1em;
 }
 

--- a/documentation.html
+++ b/documentation.html
@@ -253,7 +253,7 @@
           <h2 class="display-inlineBlock">Basic Button</h2>
           <button class="sbtn basic-btn blue-btn display-inlineBlock margin-left--half">Button</button>
 
-          <div class="text-under-button">
+          <div class="text text text-under-button">
             To use sButtons in your project, just add the classes of sButton you want to either
             <span class="code-text">&lt;button&gt;</span>
             or
@@ -276,7 +276,7 @@
           <h2>Block Buttons</h2>
           <button class="sbtn basic-btn blue-btn block-btn">Button</button>
 
-          <div class="text-under-button">
+          <div class="text text-under-button">
             To use sButtons with block display, add the class to either <span class="code-text">&lt;button&gt;</span> or
             <span class="code-text">&lt;a&gt;</span> tags
           </div>
@@ -293,7 +293,7 @@
           <h2 class="display-inlineBlock">Disabled Buttons</h2>
           <button class="sbtn basic-btn blue-btn disabled-btn display-inlineBlock margin-left--half">Button</button>
 
-          <div class="text-under-button">
+          <div class="text text-under-button">
             To make a <span class="code-text">&lt;button&gt;</span> or <span class="code-text">&lt;a&gt;</span> tag
             disabled, add disabled-btn class as shown below.
           </div>

--- a/documentation.html
+++ b/documentation.html
@@ -293,7 +293,7 @@
           <h2 class="display-inlineBlock">Disabled Buttons</h2>
           <button class="sbtn basic-btn blue-btn disabled-btn display-inlineBlock margin-left--half">Button</button>
 
-          <div class="text">
+          <div class="text-under-button">
             To make a <span class="code-text">&lt;button&gt;</span> or <span class="code-text">&lt;a&gt;</span> tag
             disabled, add disabled-btn class as shown below.
           </div>

--- a/documentation.html
+++ b/documentation.html
@@ -253,7 +253,7 @@
           <h2 class="display-inlineBlock">Basic Button</h2>
           <button class="sbtn basic-btn blue-btn display-inlineBlock margin-left--half">Button</button>
 
-          <div class="text">
+          <div class="text-under-button">
             To use sButtons in your project, just add the classes of sButton you want to either
             <span class="code-text">&lt;button&gt;</span>
             or
@@ -276,7 +276,7 @@
           <h2>Block Buttons</h2>
           <button class="sbtn basic-btn blue-btn block-btn">Button</button>
 
-          <div class="text">
+          <div class="text-under-button">
             To use sButtons with block display, add the class to either <span class="code-text">&lt;button&gt;</span> or
             <span class="code-text">&lt;a&gt;</span> tags
           </div>
@@ -418,7 +418,7 @@
                   <div class="row p-1">
                     <input type="radio" class="sbtn toggle-btn" name="selectOption">
                     <label class=" px-2 lead" style="margin-top:auto;">Ferrari</label>
-                  </div>  
+                  </div>
 
                 </div>
               </div>
@@ -461,14 +461,14 @@
               </div>
             </div>
           </section>
-          
+
           <section class="instruction-block" id="dark-modeElement">
             <h4 class="display-inlineBlock">Adding dark-mode as an attribute</h4>
             <div class="text">
               Adding the <code>data-theme="dark"</code> as an attribute to a div element .It can be added to any
               container element
               of the button
-              
+
 
               <div data-theme="dark">
                 <button class="sbtn dashed-btn orange-btn">Dark Mode</button>


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->

Added some text padding to text that appears underneath buttons on the documentation page. 

To do so, I created another CSS class called text-under-button, then changed the classed of the desired texts to text-under-button.  #1242 

<!-- Specify the issue it relates to, if any --->
Issue: Some text on the documentation page required some padding from the button above it. 
