### PR TITLE
Download link scroll

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -161,7 +161,7 @@
           <h2>Download CSS File</h2>
           <div class="text">
             You can download the CSS file
-            <a href="#" id="downloadGithubRawHowTo" class="cssLink">here</a> and then add it to your
+            <a href="downloadcss" id="downloadGithubRawHowTo" class="cssLink">here</a> and then add it to your
             html file in between the tags.
           </div>
           <div class="text">
@@ -418,7 +418,7 @@
                   <div class="row p-1">
                     <input type="radio" class="sbtn toggle-btn" name="selectOption">
                     <label class=" px-2 lead" style="margin-top:auto;">Ferrari</label>
-                  </div>  
+                  </div>
 
                 </div>
               </div>
@@ -461,14 +461,14 @@
               </div>
             </div>
           </section>
-          
+
           <section class="instruction-block" id="dark-modeElement">
             <h4 class="display-inlineBlock">Adding dark-mode as an attribute</h4>
             <div class="text">
               Adding the <code>data-theme="dark"</code> as an attribute to a div element .It can be added to any
               container element
               of the button
-              
+
 
               <div data-theme="dark">
                 <button class="sbtn dashed-btn orange-btn">Dark Mode</button>

--- a/documentation.html
+++ b/documentation.html
@@ -161,7 +161,7 @@
           <h2>Download CSS File</h2>
           <div class="text">
             You can download the CSS file
-            <a href="downloadcss" id="downloadGithubRawHowTo" class="cssLink">here</a> and then add it to your
+            <a href="#!" id="downloadGithubRawHowTo" class="cssLink">here</a> and then add it to your
             html file in between the tags.
           </div>
           <div class="text">


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->

To fix the scroll issue, I simply replaced "#" with "#!". I did this instead of replacing it with the id of its container in order to make the page not scroll at all, as long as there is no other element on the page named "!". 

<!-- Specify the issue it relates to, if any --->
Issue: When clicking the download CSS link on the documentation page, page would scroll to the top. #1239 
