### PR TITLE
replace br element with margin on documentation

### DIFF
--- a/assets/css/documentation.css
+++ b/assets/css/documentation.css
@@ -74,3 +74,7 @@ section {
 .margin-left--half {
   margin-left: 0.5rem;
 }
+
+.line-break {
+  margin-bottom: 15px;
+}

--- a/documentation.html
+++ b/documentation.html
@@ -282,13 +282,12 @@
             To use sButtons with block display, add the class to either <span class="code-text">&lt;button&gt;</span> or
             <span class="code-text">&lt;a&gt;</span> tags
           </div>
-          <div class="code-block-container">
+          <div class="code-block-container line-break">
             <div class="script-copy">
               <pre><code class="language-markup">&lt;button class="sbtn basic-btn block-btn"&gt;Button&lt;/button&gt;</code></pre>
               <div class="div-copy"><button class="clipboard"></button></div>
             </div>
           </div>
-          <br />
         </section>
 
         <section class="instruction-block" id="disabled">
@@ -299,7 +298,7 @@
             To make a <span class="code-text">&lt;button&gt;</span> or <span class="code-text">&lt;a&gt;</span> tag
             disabled, add disabled-btn class as shown below.
           </div>
-          <div class="code-block-container">
+          <div class="code-block-container line-break">
             <div class="script-copy">
               <pre><code class="language-markup">&lt;button class="sbtn basic-btn blue-btn disabled-btn"&gt;Button&lt;/button&gt;</code></pre>
               <div class="div-copy"><button class="clipboard"></button></div>
@@ -309,23 +308,24 @@
               <div class="div-copy"><button class="clipboard"></button></div>
             </div>
           </div>
-          <br />
         </section>
         <!-- base button class without any icon starts here -->
         <section class="instruction-block" id="base">
           <h2 id="base-icon-btn">Base Icon Button</h2>
-          <div class="text">
+          <div class="text line-break">
             The <code>base-icon-btn</code> class enables you to have a normal, customizable button.
             Using it, you decide to add any fontawesome icon in it. You can choose to either place it on the
             left or right side of the button with the available classes.
           </div>
-          <br />
+
           <section class="instruction-block" id="iconNoBg">
             <h4 class="display-inlineBlock">Icon With No Background</h4>
             <div class="text">
-              The <code>base-icon-btn</code> class alone gives you a default button with no background color and a
-              border.
-              <br><br>
+              <p class="line-break">
+                The <code>base-icon-btn</code> class alone gives you a default button with no background color and a
+                border.
+              </p>
+
               <button class="sbtn base-icon-btn">
                 <i class="fas fa-book"></i>
               </button>
@@ -340,8 +340,10 @@
           <section class="instruction-block" id="iconPositionLeft">
             <h4 class="display-inlineBlock">Icon Positioned to The Left</h4>
             <div class="text">
-              Adding the <code>left-icon</code> class to a button makes the icon positioned to the left. For example:
-              <br><br>
+              <p class="line-break">
+                Adding the <code>left-icon</code> class to a button makes the icon positioned to the left. For example:
+              </p>
+
               <button class="sbtn base-icon-btn icon-left orange-btn">
                 <i class="fas fa-book"></i>
                 To the Left
@@ -357,8 +359,10 @@
           <section class="instruction-block" id="iconPositionRight">
             <h4 class="display-inlineBlock">Icon Positioned to The Right</h4>
             <div class="text">
-              Adding the <code>right-icon</code> class to a button makes the icon positioned to the right. For example:
-              <br><br>
+              <p class="line-break">
+                Adding the <code>right-icon</code> class to a button makes the icon positioned to the right. For example:
+              </p>
+
               <button class="sbtn base-icon-btn icon-right orange-btn">
                 To the Right
                 <i class="fas fa-book"></i>
@@ -375,19 +379,21 @@
         <!-- Toggle button class starts here -->
         <section class="instruction-block" id="toggle">
           <h2 id="base-icon-btn">Toggle Button</h2>
-          <div class="text">
+          <div class="text line-break">
             The <code>toggle-btn</code> class along with the <code>toggle-off-btn</code> / <code>toggle-on-btn</code>
             state class enables you to have a toggle button. Apart from the basic use, it can also be used for
             checkboxes and radio buttons. While not necessary, you can use the available state classes to choose whether
             your checkboxes and radio buttons are checked or not.
           </div>
-          <br />
+          
           <section class="instruction-block" id="toggleCheckbox">
             <h4 class="display-inlineBlock">Toggle Button as Checkboxes</h4>
             <div class="text">
-              Adding the <code>toggle-btn</code> class to your checkbox inputs converts them to toggle buttons. For
-              example:
-              <br><br>
+              <p class="line-break">
+                Adding the <code>toggle-btn</code> class to your checkbox inputs converts them to toggle buttons. For
+                example:
+              </p>
+
               <input type="checkbox" class="sbtn toggle-btn" />
             </div>
             <div class="code-block-container">
@@ -400,11 +406,13 @@
           <section class="instruction-block" id="toggleRadio">
             <h4 class="display-inlineBlock">Toggle Button as Radio Button</h4>
             <div class="text">
-              Adding the <code>toggle-btn</code> class to your radio inputs converts them to toggle buttons. For
-              example:
-              <br><br>
-              <h5 class="display-inlineBlock">Select favourite car brand : </h5> <br>
-              <div class="row">
+              <p class="line-break">
+                Adding the <code>toggle-btn</code> class to your radio inputs converts them to toggle buttons. For
+                example:
+              </p>
+              
+              <h5 class="display-inlineBlock">Select favourite car brand : </h5>
+              <div class="row line-break">
                 <div class="collumn" style="margin-left: 40px;">
 
                   <div class="row p-1">
@@ -425,7 +433,6 @@
                 </div>
               </div>
 
-              <br>
             </div>
             <div class="code-block-container">
               <div class="script-copy">
@@ -452,8 +459,10 @@
           <section class="instruction-block" id="dark-modeClass">
             <h4 class="display-inlineBlock">Adding dark-mode as a class</h4>
             <div class="text">
-              Adding the <code>dark-mode</code> class :
-              <br><br>
+              <p class="line-break">
+                Adding the <code>dark-mode</code> class :
+              </p>
+
               <button class="sbtn dashed-btn orange-btn dark-mode">Dark-Mode </button>
             </div>
             <div class="code-block-container">


### PR DESCRIPTION
Replace br elements with padding on the documentation page.

 - [x] created a `line-break` CSS class
 - [x] added it to each element before the be, then remove the br

Issue: #1246

