### PR TITLE
documentation issue- icon without bg

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -348,17 +348,17 @@
             <h4 class="display-inlineBlock">Icon With No Background</h4><a  href="#iconNoBg"     class="icon-link"><i class="fas fa-link"  ></i></a>
             <div class="text">
               <p class="line-break">
-                The <code>base-icon-btn</code> class alone gives you a default button with no background color and a
+                The <code>icon-btn</code> class alone gives you a default button with no background color and a
                 border.
               </p>
 
-              <button class="sbtn base-icon-btn">
+              <button class="sbtn icon-btn">
                 <i class="fas fa-book"></i>
               </button>
             </div>
             <div class="code-block-container">
               <div class="script-copy">
-                <pre><code class="language-markup">&lt;button class="sbtn base-icon-btn"&gt;&lt;i class="fas fa-book"&gt;&lt;/i&gt;&lt;/button&gt;</code></pre>
+                <pre><code class="language-markup">&lt;button class="sbtn icon-btn"&gt;&lt;i class="fas fa-book"&gt;&lt;/i&gt;&lt;/button&gt;</code></pre>
                 <div class="div-copy"><button class="clipboard"></button></div>
               </div>
             </div>


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->

<!-- Specify the issue it relates to if any --->
Issue: In the documentation page under Icon with no background change the class of the example button from base-icon-btn to icon-btn. This should be changed in the button and the code example
