### PR TITLE
Modifycolor

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -348,17 +348,17 @@
             <h4 class="display-inlineBlock">Icon With No Background</h4><a  href="#iconNoBg"     class="icon-link"><i class="fas fa-link"  ></i></a>
             <div class="text">
               <p class="line-break">
-                The <code>base-icon-btn</code> class alone gives you a default button with no background color and a
+                The <code>icon-btn</code> class alone gives you a default button with no background color and a
                 border.
               </p>
 
-              <button class="sbtn base-icon-btn">
+              <button class="sbtn icon-btn">
                 <i class="fas fa-book"></i>
               </button>
             </div>
             <div class="code-block-container">
               <div class="script-copy">
-                <pre><code class="language-markup">&lt;button class="sbtn base-icon-btn"&gt;&lt;i class="fas fa-book"&gt;&lt;/i&gt;&lt;/button&gt;</code></pre>
+                <pre><code class="language-markup">&lt;button class="sbtn icon-btn"&gt;&lt;i class="fas fa-book"&gt;&lt;/i&gt;&lt;/button&gt;</code></pre>
                 <div class="div-copy"><button class="clipboard"></button></div>
               </div>
             </div>

--- a/documentation.html
+++ b/documentation.html
@@ -256,13 +256,13 @@
           <h2>Modifying Button Colors</h2><a  href="#modify"     class="icon-link"><i class="fas fa-link"  ></i></a>
 
           <div class="text">
-            <p>To modify button colors, import <span class="code-text">src/sbuttons.less</span> in your Less file,
+            <p>To modify button colors, import <span class="code-text">src/_variables.less</span> in your Less file,
               then make changes to the variables after the import.</p>
             <p>For example, to change the blue color to a different shade</p>
           </div>
           <div class="code-block-container">
             <div class="script-copy">
-              <pre><code class="language-javascript">@import '/path/to/sbuttons.less';</code></pre>
+              <pre><code class="language-javascript">@import '/path/to/_variables.less';</code></pre>
               <div class="div-copy"><button class="clipboard"></button></div>
             </div>
             <div class="script-copy">
@@ -271,8 +271,8 @@
             </div>
           </div>
           <div class="text">
-            Check out <a href="https://github.com/sButtons/sbuttons/blob/master/src/sbuttons.less"
-              target="_blank">sbuttons.less</a> for the full list of variables.
+            Check out <a href="https://github.com/sButtons/sbuttons/blob/master/src/_variables.less"
+              target="_blank">_variables.less</a> for the full list of variables.
           </div>
         </section>
 


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->

<!-- Specify the issue it relates to, if any --->
Issue: In the documentation page under Modify Button Colors the link to the variables file goes to sbuttons.less instead. The text should be changed to "_variables.less" and the link as well.
