### PR TITLE
Loader moved below heading in example page

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -150,9 +150,6 @@
     </header>
     <script async type="text/javascript" src="https://cdn.carbonads.com/carbon.js?serve=CEBILKJI&placement=sbuttonsgithubio" id="_carbonads_js"></script>
     <div class="main-content">
-      <div class="container mt-5" id="loading_wheel">
-        <div class="loader"></div>
-      </div>
       <div class="row">
         <div class="col-md-3 d-md-block sidebar-div">
           <div
@@ -169,6 +166,9 @@
             <h1>Some Examples Of sButtons</h1>
           </div>
           <!-- Button examples will go here using JS -->
+        </div>
+        <div class="container mt-5" id="loading_wheel">
+          <div class="loader"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->
Moved Loader below Heading "Some Examples Of sButtons" in Example Page
<!-- Specify the issue it relates to, if any --->
Issue: Move Loader in Examples Page below heading #1257
