### PR TITLE
Added transition to rounded-diagonal buttons

### DIFF
--- a/dist/sbuttons.css
+++ b/dist/sbuttons.css
@@ -664,6 +664,7 @@ a.yellow-btn:active:not(.fill-color-btn) {
 }
 .rounded-diagonal-tl-btn {
   border-radius: 24px 4px;
+  transition: all 0.2s;
 }
 .rounded-diagonal-tl-btn:hover {
   box-shadow: 0 10px 10px rgba(0, 0, 0, 0.3);
@@ -676,6 +677,7 @@ a.yellow-btn:active:not(.fill-color-btn) {
 }
 .rounded-diagonal-tr-btn {
   border-radius: 4px 24px;
+  transition: all 0.2s;
 }
 .rounded-diagonal-tr-btn:hover {
   box-shadow: 0 10px 10px rgba(0, 0, 0, 0.3);

--- a/src/components/styles/_rounded-diagonal-tl.less
+++ b/src/components/styles/_rounded-diagonal-tl.less
@@ -1,5 +1,6 @@
 .rounded-diagonal-tl-btn {
   border-radius: 24px 4px;
+  transition: all 0.2s;
   &:hover {
     box-shadow: 0 10px 10px rgba(@black, 0.3);
   }

--- a/src/components/styles/_rounded-diagonal-tr.less
+++ b/src/components/styles/_rounded-diagonal-tr.less
@@ -1,5 +1,6 @@
 .rounded-diagonal-tr-btn {
   border-radius: 4px 24px;
+  transition: all 0.2s;
   &:hover {
     box-shadow: 0 10px 10px rgba(@black, 0.3);
   }


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->
Added `transition: all 0.2s` to rounded-diagonal button, both top-left and top-right
<!-- Specify the issue it relates to, if any --->
Issue: #1263 
