### PR TITLE
sidebar issue solved, issue: #1258

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -51,7 +51,7 @@ body {
     padding-top: 20%;
   }
   .sidebar.scrolling {
-    width: calc(100vw / 12 * 3 - 5vw);
+    width: calc(100vw / 12 * 3);
   }
 }
 


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->

<!-- Specify the issue it relates to, if any --->
Issue: Sidebar behavior before scroll #1258
Changes done: Removed "- 5vw" in navbar scrolling effect from main.css, now sidebar's width won't get reduced on scrolling.
