### PR TITLE
Fix punctuation typo in the documentation

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -500,9 +500,9 @@
           <section class="instruction-block" id="dark-modeElement">
             <h4 class="display-inlineBlock">Adding dark-mode as an attribute</h4><a  href="#dark-modeElement"     class="icon-link"><i class="fas fa-link"  ></i></a>
             <div class="text">
-              Adding the <code>data-theme="dark"</code> as an attribute to a div element .It can be added to any
+              Adding the <code>data-theme="dark"</code> as an attribute to a div element. It can be added to any
               container element
-              of the button
+              of the button.
 
 
               <div data-theme="dark">


### PR DESCRIPTION
Issue: Space should be placed after ".", not before
