### PR TITLE
Removes unnecessary files in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "buttons",
     "css"
   ],
+  "files": [
+    "src/",
+    "dist/"
+  ],
   "scripts": {
     "start": "npm run watch",
     "compile": "lessc src/sbuttons.less dist/sbuttons.css && npm run prettier",


### PR DESCRIPTION
Reduce published npm package size from __150.5 kB__ to __51.8 kB__ by using ["files" field](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files) in `package.json`.
Only folders and files that likely `required` by users are included, thus `src/` and `dist/`. Note that important files like `package.json` and `README.md` are automatically included by npm, so no need to explicitly include them.
[This](https://www.diffchecker.com/Qtlnw3F7) shows the comparison of files published before and after using "files" field.