### PR TITLE
Footer Link Problem Solved

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -545,7 +545,7 @@
         <div class="footer-links">
           <a href="https://github.com/sButtons/sbuttons" target="_blank" title="View on Github"> <i
               class="fab fa-github"></i> GitHub</a>
-          <a href="https://github.com/sButtons/sbuttons" target="_blank" title="View on Github"> <i
+          <a href="https://sbuttons.github.io/sbuttons/examples.html" target="_blank" title="View on Github"> <i
               class="fas fa-book"></i> Examples</a>
           <a href="https://github.com/sButtons/sbuttons/issues/new/choose" target="_blank" title="View on Github"> <i
               class="fas fa-bug"></i> Report A Bug</a>

--- a/examples.html
+++ b/examples.html
@@ -204,7 +204,7 @@
               <i class="fab fa-github"></i> GitHub</a
             >
             <a
-              href="https://github.com/sButtons/sbuttons"
+              href="https://sbuttons.github.io/sbuttons/examples.html"
               target="_blank"
               title="View on Github"
             >


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->
In this PR I have changed the link of Examples in the footer section of the documentation and examples page to point to the examples page of our website rather than to the Github repo of our project.
<!-- Specify the issue it relates to, if any --->
Issue: Footer link problem #1336
