### PR TITLE
Fix for #1346, changed where css files were imported in projects.html

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -75,11 +75,3 @@ main {
   color: #fff;
 }
 /* dark mode style ends here */
-.btn-group ul {
-  background: var(--sidebar-color);
-  color: #fff;
-}
-.btn-group li a,
-.btn-group li i {
-  color: #ebebed;
-}

--- a/projects.html
+++ b/projects.html
@@ -10,7 +10,6 @@
       href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="assets/css/projects.css" />
     <!-- bootstrap and fontawesome css -->
     <link
       rel="stylesheet"
@@ -26,6 +25,8 @@
     />
     <!-- favicon -->
     <link rel="icon" type="image/png" href="favicon.png" />
+    <!-- Local stylesheets -->
+    <link href="assets/css/projects.css" rel="stylesheet"/>
     <link href="assets/css/main.css" rel="stylesheet" />
     <link href="assets/css/header.css" rel="stylesheet" />
     <link href="assets/css/footer.css" rel="stylesheet" />

--- a/projects.html
+++ b/projects.html
@@ -5,10 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Projects using sButtons - sButtons</title>
-    <link href="assets/css/main.css" rel="stylesheet" />
-    <link href="assets/css/header.css" rel="stylesheet" />
-    <link href="assets/css/footer.css" rel="stylesheet" />
-    <link href="assets/css/variables.css" rel="stylesheet" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
       href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500&display=swap"
@@ -30,7 +26,10 @@
     />
     <!-- favicon -->
     <link rel="icon" type="image/png" href="favicon.png" />
-
+    <link href="assets/css/main.css" rel="stylesheet" />
+    <link href="assets/css/header.css" rel="stylesheet" />
+    <link href="assets/css/footer.css" rel="stylesheet" />
+    <link href="assets/css/variables.css" rel="stylesheet" />
     <!-- seo friendly og tags-->
     <meta
       name="description"


### PR DESCRIPTION
Issue: #1346

I changed where the links to the local stylesheets occurred in order to match how it works in index.html. There were many rules being erroneously overwritten as seen here:
![image](https://i.ibb.co/b6Hpdnk/Screenshot-from-2021-03-13-19-55-03.png)

After placing the local stylesheets after the bootstrap/fontawesome ones, the dropdown menu now has the correct highlighting. Along with this, some rules in projects.css were removed so that it has the same applied rules as the dropdown in index.html. The removed rules served no purpose (that I could see, I apologize if these were put in for another reason). 