### PR TITLE
Bug/copy btn text

### DIFF
--- a/website/src/components/Button.js
+++ b/website/src/components/Button.js
@@ -24,13 +24,18 @@ function Button ({classes, text, htmlContent}) {
 
     const copyClasses = classes ? getCopyClasses(classes) : ""
 
+    function testFunc (codeWithPeriods) {
+        classes.replace('.', " ")
+        return classes
+    };
+
     return (
         <div className="flex flex-col items-center justify-items-center pb-5 pr-3 md:w-4/12 w-6/12">
             <button className={`${classes} max-w-full`}>
                 {htmlContent && htmlContent.length && <div dangerouslySetInnerHTML={{__html: htmlContent}}></div>}
                 {(!htmlContent || !htmlContent.length) && text}
             </button>
-            <CopyToClipboard text={copyClasses} onCopy={showToast}>
+            <CopyToClipboard text={testFunc({classes})} onCopy={showToast}>
                 <span className="mt-3 text-gray-500 text-sm text-center cursor-pointer">
                     <FiCopy className="inline-block" />
                     <span className="pl-3">{copyClasses}</span>

--- a/website/src/components/Button.js
+++ b/website/src/components/Button.js
@@ -24,7 +24,7 @@ function Button ({classes, text, htmlContent}) {
 
     const copyClasses = classes ? getCopyClasses(classes) : ""
 
-    function testFunc (codeWithPeriods) {
+    function removePeriodsOnCopy (codeWithPeriods) {
         classes.replace('.', " ")
         return classes
     };
@@ -35,7 +35,7 @@ function Button ({classes, text, htmlContent}) {
                 {htmlContent && htmlContent.length && <div dangerouslySetInnerHTML={{__html: htmlContent}}></div>}
                 {(!htmlContent || !htmlContent.length) && text}
             </button>
-            <CopyToClipboard text={testFunc({classes})} onCopy={showToast}>
+            <CopyToClipboard text={removePeriodsOnCopy({classes})} onCopy={showToast}>
                 <span className="mt-3 text-gray-500 text-sm text-center cursor-pointer">
                     <FiCopy className="inline-block" />
                     <span className="pl-3">{copyClasses}</span>


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->

- [x] read the contrib guide

<!-- Please describe what changes or additions this pull request pertain to -->
Removed periods and replaced them white blank spaces when copying the code for a button by adding a function in /Components/Button.js. I tried to make the change in /Components/Code.js as you noted but nothing was altering the text being copied until I found that it was within `getCopyClasses` in Button.js that the periods were being inserted in, and so that is where I made the change.
Please let me know what you'd like me to change though, as I know you said this would impact behavior in other places on the website. I checked the functionality with other button types, and everything behaved normally, so I'm not sure what I should be checking for. Do let me know! Thank you!

<!-- Specify the issue it relates to, if any --->
Issue: Fix copy button [#1386](https://github.com/sButtons/sbuttons/issues/1386)
