### PR TITLE
Added CSS download link in README file. Fix for 1418

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Logo made by [Harshit Sharma](https://www.github.com/icoderharshit)
 
 ## Download CSS File
 
-You can download the CSS file here and then add it to your HTML file in between the tags.
+You can download the CSS file here ( [Download Link](https://raw.githubusercontent.com/sButtons/sbuttons/master/dist/sbuttons.min.css) ) and then add it to your HTML file in between the tags.
 Download the file and link it as a stylesheet in between your `<head>` tags, as shown below.
 
 ```html

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Logo made by [Harshit Sharma](https://www.github.com/icoderharshit)
 
 ## Download CSS File
 
-You can download the CSS file here ( [Download Link](https://raw.githubusercontent.com/sButtons/sbuttons/master/dist/sbuttons.min.css) ) and then add it to your HTML file in between the tags.
+You can download the (CSS file)(https://raw.githubusercontent.com/sButtons/sbuttons/master/dist/sbuttons.min.css) and then add it to your HTML file in between the tags.
 Download the file and link it as a stylesheet in between your `<head>` tags, as shown below.
 
 ```html


### PR DESCRIPTION
Added a link in README.md file which leads to CSS file.

Issue: The `Download` button in the website doesn't download the file, instead it leads to the file, and so as the link added in the README because I took the link address from there.