### PR TITLE
Fix typo in brand name on home page

### DIFF
--- a/website/src/pages/Home/index.js
+++ b/website/src/pages/Home/index.js
@@ -21,7 +21,7 @@ function Home () {
                     </h2>
                     <div className="gap-12 grid md:grid-cols-2 text-xl mt-2">
                         <p>
-                            Install sButttons’s source LESS via npm.
+                            Install sButtons’s source LESS via npm.
                             Package managed installs don’t include documentation or our full build scripts. 
                             You can also use our npm.
                         </p>


### PR DESCRIPTION
# Summary

The brand name in the first sentence of the first paragraph on the home page is misspelled.

## Problem

In the sentence, `Install sButttons’s source LESS via npm.`, the brand name is incorrectly spelled with three t's.

## Solution

The sentence should read, `Install sButtons’s source LESS via npm.`, with the brand name correctly spelled with two t's.

<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->

<!-- Specify the issue it relates to, if any --->
Issue:
