### PR TITLE
Fixed spotlight button text color for dark mode

### DIFF
--- a/website/src/components/Button.js
+++ b/website/src/components/Button.js
@@ -31,7 +31,7 @@ function Button ({classes, text, htmlContent}) {
 
     return (
         <div className="flex flex-col items-center justify-items-center pb-5 pr-3 md:w-4/12 w-6/12">
-            <button className={`${classes} max-w-full`}>
+            <button className={`${classes} max-w-full dark:text-white`}>
                 {htmlContent && htmlContent.length && <div dangerouslySetInnerHTML={{__html: htmlContent}}></div>}
                 {(!htmlContent || !htmlContent.length) && text}
             </button>


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/sButtons/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->
This PR has fixed issue of spotlight buttons' text color for dark mode.
<!-- Specify the issue it relates to, if any --->
Issue: In dark mode, Spotlight buttons' text color should be white before the animation but it was dark.